### PR TITLE
add notes field - use for longform of question

### DIFF
--- a/gdcdictionary/schemas/observation.yaml
+++ b/gdcdictionary/schemas/observation.yaml
@@ -87,6 +87,11 @@ properties:
     type:
       - number
       - "null"
+      
+  notes:
+    description: >
+      Additional information
+    type: string
 
 
   description:


### PR DESCRIPTION
key field for behavior survey questions, where the details of question can't be fully captured in property naming